### PR TITLE
fix: remove invalid `category` field from plugin.json manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,6 +12,56 @@
   },
   "plugins": [
     {
+      "name": "bun",
+      "source": "./plugins/bun",
+      "description": "Production-ready TypeScript backend development with Bun runtime. Includes specialized agents for backend development, API design, Apidog synchronization, and DevOps.",
+      "version": "1.6.1",
+      "author": {
+        "name": "Jack Rudenko",
+        "email": "i@madappgang.com",
+        "company": "MadAppGang"
+      },
+      "category": "development",
+      "keywords": [
+        "bun",
+        "typescript",
+        "backend",
+        "hono",
+        "prisma",
+        "biome",
+        "docker",
+        "aws-ecs",
+        "api",
+        "apidog",
+        "openapi",
+        "testing"
+      ],
+      "strict": true
+    },
+    {
+      "name": "frontend",
+      "source": "./plugins/frontend",
+      "description": "Comprehensive frontend development toolkit with TypeScript, React 19, Vite, TanStack Router & Query v5, shadcn/ui. Features multi-model code review, browser debugging, and Chrome DevTools MCP integration.",
+      "version": "3.15.1",
+      "author": {
+        "name": "Jack Rudenko",
+        "email": "i@madappgang.com",
+        "company": "MadAppGang"
+      },
+      "category": "development",
+      "keywords": [
+        "frontend",
+        "typescript",
+        "react",
+        "vite",
+        "tanstack",
+        "testing",
+        "architecture",
+        "ui-testing"
+      ],
+      "strict": true
+    },
+    {
       "name": "code-analysis",
       "source": "./plugins/code-analysis",
       "description": "Deep code investigation with claudemem. v3.2.2: Updated for claudish v4.5.1 (--agent flag removed). v3.0.0: ENRICHMENT MODE.",
@@ -250,6 +300,54 @@
         "customization",
         "themes",
         "reset-countdown"
+      ],
+      "strict": true
+    },
+    {
+      "name": "instantly",
+      "source": "./plugins/instantly",
+      "description": "Cold email outreach toolkit with Instantly.ai MCP integration. Features campaign analytics, sequence building, A/B testing, lead management, and auto-optimization.",
+      "version": "1.0.2",
+      "author": {
+        "name": "Jack Rudenko",
+        "email": "i@madappgang.com",
+        "company": "MadAppGang"
+      },
+      "category": "productivity",
+      "keywords": [
+        "instantly",
+        "cold-email",
+        "outreach",
+        "email-campaigns",
+        "lead-generation",
+        "ab-testing",
+        "email-sequences",
+        "deliverability",
+        "sales-automation"
+      ],
+      "strict": true
+    },
+    {
+      "name": "autopilot",
+      "source": "./plugins/autopilot",
+      "description": "Autonomous task execution with Linear integration. Picks tasks from Linear, routes to appropriate agents, generates proof-of-work artifacts, and handles feedback loops.",
+      "version": "0.2.0",
+      "author": {
+        "name": "Jack Rudenko",
+        "email": "i@madappgang.com",
+        "company": "MadAppGang"
+      },
+      "category": "automation",
+      "keywords": [
+        "autopilot",
+        "autonomous",
+        "linear",
+        "task-execution",
+        "proof-of-work",
+        "webhook",
+        "state-machine",
+        "feedback-loop",
+        "multi-agent"
       ],
       "strict": true
     }

--- a/plugins/autopilot/plugin.json
+++ b/plugins/autopilot/plugin.json
@@ -19,7 +19,6 @@
     "feedback-loop",
     "multi-agent"
   ],
-  "category": "automation",
   "agents": [
     "./agents/task-executor.md",
     "./agents/proof-generator.md",

--- a/plugins/bun/plugin.json
+++ b/plugins/bun/plugin.json
@@ -22,7 +22,6 @@
     "openapi",
     "testing"
   ],
-  "category": "development",
   "agents": [
     "./agents/backend-developer.md",
     "./agents/api-architect.md",

--- a/plugins/code-analysis/plugin.json
+++ b/plugins/code-analysis/plugin.json
@@ -23,7 +23,6 @@
     "enrichment",
     "context-enhancement"
   ],
-  "category": "development",
   "hooks": "./hooks/hooks.json",
   "mcpServers": "./.mcp.json",
   "agents": [

--- a/plugins/dev/plugin.json
+++ b/plugins/dev/plugin.json
@@ -40,7 +40,6 @@
     "multimodal",
     "vision"
   ],
-  "category": "development",
   "mcpServers": "./.mcp.json",
   "agents": [
     "./agents/stack-detector.md",

--- a/plugins/frontend/plugin.json
+++ b/plugins/frontend/plugin.json
@@ -18,7 +18,6 @@
     "architecture",
     "ui-testing"
   ],
-  "category": "development",
   "agents": [
     "./agents/developer.md",
     "./agents/architect.md",

--- a/plugins/instantly/plugin.json
+++ b/plugins/instantly/plugin.json
@@ -19,7 +19,6 @@
     "deliverability",
     "sales-automation"
   ],
-  "category": "productivity",
   "dependencies": {
     "orchestration@mag-claude-plugins": "^0.8.0"
   },

--- a/plugins/nanobanana/plugin.json
+++ b/plugins/nanobanana/plugin.json
@@ -16,7 +16,6 @@
     "image-editing",
     "style-transfer"
   ],
-  "category": "media",
   "agents": [
     "./agents/style-manager.md",
     "./agents/image-generator.md"

--- a/plugins/seo/plugin.json
+++ b/plugins/seo/plugin.json
@@ -19,7 +19,6 @@
     "search-console",
     "performance-analysis"
   ],
-  "category": "content",
   "dependencies": {
     "orchestration@mag-claude-plugins": "^0.5.0"
   },

--- a/plugins/statusline/plugin.json
+++ b/plugins/statusline/plugin.json
@@ -16,7 +16,6 @@
     "customization",
     "themes"
   ],
-  "category": "utility",
   "commands": [
     "./commands/install.md",
     "./commands/uninstall.md",

--- a/plugins/video-editing/plugin.json
+++ b/plugins/video-editing/plugin.json
@@ -19,7 +19,6 @@
     "audio",
     "editing"
   ],
-  "category": "media",
   "agents": [
     "./agents/video-processor.md",
     "./agents/transcriber.md",


### PR DESCRIPTION
## Summary

- Remove the `category` field from 10 `plugin.json` files that was causing plugin installation failures
- Add 4 missing plugins (bun, frontend, instantly, autopilot) to `.claude-plugin/marketplace.json` to preserve their category values

## Problem

When installing plugins via `/plugin install`, the following error occurs:

```
Failed to install: Plugin has an invalid manifest file at .../plugin.json.
Validation errors: : Unrecognized key: "category"
```

The `category` field is a **marketplace-specific** property valid only in `.claude-plugin/marketplace.json` entries, not in individual plugin manifests (`plugin.json`). Per the [Claude Code plugin marketplace documentation](https://code.claude.com/docs/en/plugin-marketplaces), fields like `category`, `tags`, `source`, and `strict` belong exclusively to marketplace registry entries.

## Changes

**Removed `category` from `plugin.json` in:**
| Plugin | Category value |
|--------|---------------|
| `plugins/code-analysis/plugin.json` | `development` |
| `plugins/bun/plugin.json` | `development` |
| `plugins/frontend/plugin.json` | `development` |
| `plugins/dev/plugin.json` | `development` |
| `plugins/seo/plugin.json` | `content` |
| `plugins/video-editing/plugin.json` | `media` |
| `plugins/nanobanana/plugin.json` | `media` |
| `plugins/statusline/plugin.json` | `utility` |
| `plugins/instantly/plugin.json` | `productivity` |
| `plugins/autopilot/plugin.json` | `automation` |

**Added to `.claude-plugin/marketplace.json`:**
4 plugins that were missing from the marketplace registry (bun, frontend, instantly, autopilot) — added with their respective category values to ensure no data is lost.

The remaining 6 plugins already had matching `category` entries in `marketplace.json`.

## Test plan

- [ ] Verify all modified JSON files are valid (validated locally with `python3 -m json.tool`)
- [ ] Verify no `category` field remains in any `plugins/*/plugin.json`
- [ ] Test plugin installation with `/plugin install` — should no longer produce `Unrecognized key: "category"` error